### PR TITLE
feat: deploy to GitHub pages with actions

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -36,7 +36,9 @@ jobs:
         with:
           node-version: 20
       - name: Build Project
-        run: npm run build
+        run: |
+          npm install
+          npm run build
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
-          path: './dist'
+          path: './build'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,49 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy content to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Build Project
+        run: npm run build
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Upload entire repository
+          path: './dist'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nbateams2",
   "version": "0.1.0",
-  "homepage": "https://wereouts.github.io/nbateams3",
+  "homepage": "https://wereouts.github.io/nbateams2",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.4",

--- a/src/componentes/Rodape/index.js
+++ b/src/componentes/Rodape/index.js
@@ -11,7 +11,7 @@ const Rodape = () => {
                     </a>
                 </li>
                 <li>
-                    <a href="https://www.instagram.com/guilhermi.png/" target="_blank">
+                    <a href="https://www.instagram.com/guilhermi.png/" target="_blank" rel="noreferrer">
                         <img src="/imagens/instagram.png" alt="" />
                     </a>
                 </li>


### PR DESCRIPTION
Olá, este pull request [adiciona uma workflow ](https://github.com/brenoepics/nbateams2/blob/96ca0c6a6f5c86d33d7d6da333f03304426da06c/.github/workflows/deploy-pages.yml) para fazer o deploy para a GitHub pages sempre que o repositorio receber um `push` ou rodar manualmente com a `workflow_dispatch`, além disso, também adicionei alguns fixes:
- a homepage utilizava o nome nbateams3 que conflitava com o nome do repositorio que é nbateams2.
- adicionei um `rel="noreferrer"` para evitar de enviar alguns headers para o target no link do Instagram assim evitamos algumas vulnerabilidades.

antes de dar merge neste pr, lembre-se de mudar o modo de deploy das pages que agora utiliza artefatos
![image](https://github.com/Wereouts/nbateams2/assets/59066707/ae006f9f-32be-4328-98ba-cdaf6ec22567)
